### PR TITLE
Adding aws-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ FROM grafana/grafana:7.0.3
 # Expose grafana port
 EXPOSE 3000
 
+USER root
+
+RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories && \
+    apk upgrade --update-cache --available && \
+    apk add --no-cache aws-cli
 
 COPY entrypoint.sh /bin/entrypoint.sh
-USER root
 RUN chmod 0755 /bin/entrypoint.sh
 
 USER grafana


### PR DESCRIPTION
- Had to update packages to edge repository in order to add AWS cli as it's only on edge https://pkgs.alpinelinux.org/packages?name=aws-cli&branch=edge

That is for 3.11